### PR TITLE
Add udev rule for managing ZFS device permissions

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -25,6 +25,7 @@ suites:
   - name: source
     data_bags_path: "test/integration/data_bags"
     run_list:
+      - recipe[apt]
       - recipe[zfs_linux::source]
       - recipe[zfs_linux-test::default]
     attributes:

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ Contributing
 
 1. Fork the repository on Github
 2. Create a named feature branch (like `add_component_x`)
-3. Write you change
+3. Write your change
 4. Write tests for your change (if applicable)
 5. Run the tests, ensuring they all pass
 6. Submit a Pull Request using Github
 
 License and Authors
 -------------------
- Copyright 2014, Biola University 
+ Copyright 2014, Biola University
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -110,4 +110,3 @@ License and Authors
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,9 @@ default['zol']['spl_repo']                                         = "https://gi
 default['zol']['zfs_commit']                                       = "07dabd234dd51a1e5adc5bd21cddf5b5fdc70732"
 default['zol']['spl_commit']                                       = "31cb5383bff0fddc5058973e32a6f2c446d45e59"
 
+default['zol']['dev_group']                                        = "root"
+default['zol']['dev_perms']                                        = "600"
+
 case node['platform_version']
 when '12.04'
   default['zol']['mountall_url']                                   = "http://ppa.launchpad.net/zfs-native/daily/ubuntu/pool/main/m/mountall/mountall_2.36.4-zfs2_amd64.deb"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: zfs_linux
 # Recipe:: default
 #
-# Copyright 2013, Biola University 
+# Copyright 2013, Biola University
 # Copyright (c) 2012, Cameron Johnston
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,9 +21,9 @@
 case node['platform']
 when "ubuntu"
   if node['platform_version'].to_f >= 10.04
-    
+
     include_recipe 'apt'
-    
+
     apt_repository 'zfs-native' do
       uri 'http://ppa.launchpad.net/zfs-native/stable/ubuntu'
       distribution node['lsb']['codename']
@@ -32,23 +32,33 @@ when "ubuntu"
       key 'F6B0FC61'
       action :add
     end
-    
+
     # Ensure headers for the current kernel are installed
     uname = Mixlib::ShellOut.new('uname -r')
     kernel = uname.run_command.stdout.chomp
     package "linux-headers-#{kernel}" do
       not_if { File.directory?("/usr/src/linux-headers-#{kernel}") }
     end
-    
+
     package 'ubuntu-zfs' do
       action :install
-      notifies :run, 'execute[load_zfs_module]', :immediately
+      # Load module after udev rule is in place
     end
-    
+
     execute 'load_zfs_module' do
       command 'modprobe zfs'
       action :nothing
     end
-    
+
+    group node['zol']['dev_group']
+
+    template '/etc/udev/rules.d/91-zfs-permissions.rules' do
+      source '91-zfs-permissions.rules.erb'
+      owner 'root'
+      group 'root'
+      variables :mode => node['zol']['dev_perms'], :group => node['zol']['dev_group']
+      notifies :run, 'execute[load_zfs_module]', :immediately
+    end
+
   end
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: zfs_linux
 # Recipe:: source
 #
-# Copyright 2014, Biola University 
+# Copyright 2014, Biola University
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ include_recipe 'zfs_linux::build_tools'
 # Perform the installation
 if node['platform_family'] == 'debian'
   if node['platform_version'].to_f >= 12.04
-    
+
     # This will start the chain of download/compilation
     # So it's always possible to start over by deleting
     # /var/chef/cache/spl & /var/chef/cache/zfs
@@ -33,28 +33,28 @@ if node['platform_family'] == 'debian'
       revision node['zol']['spl_commit']
       notifies :run, 'execute[autogen_spl]'
     end
-    
+
     execute 'autogen_spl' do
       command "#{Chef::Config[:file_cache_path]}/spl/autogen.sh"
       cwd "#{Chef::Config[:file_cache_path]}/spl"
       action :nothing
       notifies :run, 'execute[configure_spl]'
     end
-    
+
     execute 'configure_spl' do
       command "#{Chef::Config[:file_cache_path]}/spl/configure"
       cwd "#{Chef::Config[:file_cache_path]}/spl"
       action :nothing
       notifies :run, 'execute[build_spl]'
     end
-    
+
     execute 'build_spl' do
       command 'make deb-utils deb-kmod'
       cwd "#{Chef::Config[:file_cache_path]}/spl"
       action :nothing
       notifies :run, 'execute[install_spl_devel]'
     end
-    
+
     # This will install the two development packages needed for zfs
     # compilation
     execute 'install_spl_devel' do
@@ -63,61 +63,71 @@ if node['platform_family'] == 'debian'
       action :nothing
       notifies :sync, "git[#{Chef::Config[:file_cache_path]}/zfs]"
     end
-    
+
     git "#{Chef::Config[:file_cache_path]}/zfs" do
       repository node['zol']['zfs_repo']
       revision node['zol']['zfs_commit']
       notifies :run, 'execute[autogen_zfs]'
       action :nothing
     end
-    
+
     execute 'autogen_zfs' do
       command "#{Chef::Config[:file_cache_path]}/zfs/autogen.sh"
       cwd "#{Chef::Config[:file_cache_path]}/zfs"
       action :nothing
       notifies :run, 'execute[configure_zfs]'
     end
-    
+
     execute 'configure_zfs' do
       command "#{Chef::Config[:file_cache_path]}/zfs/configure"
       cwd "#{Chef::Config[:file_cache_path]}/zfs"
       action :nothing
       notifies :run, 'execute[build_zfs]'
     end
-    
+
     execute 'build_zfs' do
       command 'make deb-utils deb-kmod'
       cwd "#{Chef::Config[:file_cache_path]}/zfs"
       action :nothing
       notifies :run, 'execute[install_zfs]'
     end
-    
+
     execute 'install_zfs' do
       command 'dpkg -i spl/*.deb zfs/*.deb'
       cwd "#{Chef::Config[:file_cache_path]}"
       action :nothing
-      notifies :run, 'execute[load_zfs_module]'
+      # Load module after udev rule is in place
     end
-    
+
     execute 'load_zfs_module' do
       command 'modprobe zfs'
       action :nothing
     end
-    
+
+    group node['zol']['dev_group']
+
+    template '/etc/udev/rules.d/91-zfs-permissions.rules' do
+      source '91-zfs-permissions.rules.erb'
+      owner 'root'
+      group 'root'
+      variables :mode => node['zol']['dev_perms'], :group => node['zol']['dev_group']
+      notifies :run, 'execute[load_zfs_module]', :immediately
+    end
+
     # Custom mountall package needed to auto-mount zfs volumes
     # at boot
     remote_file 'mountall' do
       path "#{Chef::Config[:file_cache_path]}/#{node['zol']['mountall_url'].split('/').last}"
-      source node['zol']['mountall_url'] 
-      checksum node['zol']['mountall_checksum'] 
+      source node['zol']['mountall_url']
+      checksum node['zol']['mountall_checksum']
     end
-    
+
     package 'mountall' do
       source "#{Chef::Config[:file_cache_path]}/#{node['zol']['mountall_url'].split('/').last}"
       provider Chef::Provider::Package::Dpkg
       not_if 'dpkg --get-selections | grep \'^mountall\' | grep -q \'hold\''
     end
-    
+
     execute 'echo mountall hold | dpkg --set-selections' do
       not_if 'dpkg --get-selections | grep \'^mountall\' | grep -q \'hold\''
     end

--- a/templates/default/91-zfs-permissions.rules.erb
+++ b/templates/default/91-zfs-permissions.rules.erb
@@ -1,0 +1,7 @@
+#Use this to add a group and more permissive permissions for zfs
+#so that you don't always need run it as root.  beware, users not root
+#can do nearly EVERYTHING, including, but not limited to destroying
+#volumes and deleting datasets.  they CANNOT mount datasets or create new
+#volumes, export datasets via NFS, or other things that require root
+#permissions outside of ZFS.
+ACTION=="add", KERNEL=="zfs", MODE="<%= @mode %>", GROUP="<%= @group %>"

--- a/test/integration/default/serverspec/zfs_spec.rb
+++ b/test/integration/default/serverspec/zfs_spec.rb
@@ -12,6 +12,12 @@ set :path, '/sbin:/usr/sbin:$PATH'
   end
 end
 
+#Does the device exist, with the correct permissions?
+describe file('/dev/zfs') do
+  it { should be_owned_by 'root' }
+  it { should be_mode '600'}
+end
+
 # Has the pool been created?
 describe zfs('tank') do
   it { should exist }
@@ -22,6 +28,6 @@ describe command('/sbin/zfs list -t snapshot -d 1 -r tank/test') do
   its(:stdout) { should match /zfs-chef-snap-test5/ }
   its(:stdout) { should match /zfs-chef-snap-test6/ }
   its(:stdout) { should match /zfs-chef-snap-serverspec/ }
-  # 
+  #
   its(:stdout) { is_expected.not_to match /zfs-chef-snap-test3/ }
 end


### PR DESCRIPTION
There's [an outstanding "bug"](https://github.com/zfsonlinux/zfs/issues/362) in 
the zol upstream about having to run all zfs commands as root.  The maintainers 
wish to wait until proper zfs delegations support has arrived, but in the 
comments there is a udev rule that will enable read/write permission for users 
in a zfs group.  This PR implements that udev rule, but maintains the default
package permissions out of the box, so it  should remain a noop until the 
attributes are modified.