### PR TITLE
update URL for broken zfs-on-linux link.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ platforms:
   - name: ubuntu-14.04
     run_list:
     - recipe[apt]
-  - name: centos-7.1
+  - name: centos-7.2
     run_list:
     - recipe[yum-centos]
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,3 +14,5 @@ when '14.04'
   default['zol']['mountall_url'] = 'http://ppa.launchpad.net/zfs-native/daily/ubuntu/pool/main/m/mountall/mountall_2.53-zfs1_amd64.deb'
   default['zol']['mountall_checksum'] = '87f33148dd06f861f757f472464a60015bac3595ad73e4deac7a1968adec356d'
 end
+
+default['zol']['zfs-release'] = 'http://download.zfsonlinux.org/epel/zfs-release.el7.noarch.rpm'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,7 +57,7 @@ when 'centos'
   include_recipe 'yum-epel'
   
   package 'zfs-release' do
-    source 'http://archive.zfsonlinux.org/epel/zfs-release.el7.noarch.rpm'
+    source node['zol']['zfs-release']
     action :install
     provider Chef::Provider::Package::Rpm
   end


### PR DESCRIPTION
the zfs on linux page updated the url a few months ago, and finally dropped the old archive link.  this gets everything wokring again.